### PR TITLE
Add agent to create release post draft

### DIFF
--- a/.github/workflows/create-release-post-draft.yml
+++ b/.github/workflows/create-release-post-draft.yml
@@ -1,0 +1,164 @@
+name: Create release post draft
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Product version (e.g., 25.9)"
+        required: true
+        type: string
+        default: "25.9"
+      title:
+        description: "Cover title (e.g., September 2025 release)"
+        required: true
+        type: string
+        default: "September 2025 release"
+      product_name:
+        description: "Product name (e.g., GroupDocs.Viewer)"
+        required: true
+        type: choice
+        options:
+          - GroupDocs.Annotation
+          - GroupDocs.Assembly
+          - GroupDocs.Classification
+          - GroupDocs.Comparison
+          - GroupDocs.Conversion
+          - GroupDocs.Editor
+          - GroupDocs.Markdown
+          - GroupDocs.Merger
+          - GroupDocs.Metadata
+          - GroupDocs.Parser
+          - GroupDocs.Redaction
+          - GroupDocs.Search
+          - GroupDocs.Signature
+          - GroupDocs.Total
+          - GroupDocs.Viewer
+          - GroupDocs.Watermark
+        default: GroupDocs.Viewer
+      platform:
+        description: "Platform"
+        required: true
+        type: choice
+        options:
+          - .NET
+          - .NET UI
+          - Java
+          - Node.js
+          - Python
+        default: .NET
+      release_notes_url:
+        description: "Public release notes URL"
+        required: true
+        type: string
+
+jobs:
+  create:
+    name: "Draft for ${{ github.event.inputs.product_name }} for ${{ github.event.inputs.platform }} v${{ github.event.inputs.version }}"
+    runs-on: self-hosted
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.REPO_TOKEN }}
+
+      - name: Build product full name
+        id: build_name
+        run: |
+          FULL_NAME="${{ github.event.inputs.product_name }} for ${{ github.event.inputs.platform }}"
+          echo "full_name=$FULL_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Set date and slugs
+        id: slugs
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION_SLUG="${{ github.event.inputs.version }}"; VERSION_SLUG=${VERSION_SLUG//./-}
+          PLATFORM_LABEL="${{ github.event.inputs.platform }}"
+          case "$PLATFORM_LABEL" in
+            ".NET") PLATFORM_SLUG="net" ;;
+            ".NET UI") PLATFORM_SLUG="net-ui" ;;
+            "Java") PLATFORM_SLUG="java" ;;
+            "Node.js") PLATFORM_SLUG="node-js" ;;
+            "Python") PLATFORM_SLUG="python" ;;
+            *) PLATFORM_SLUG=$(echo "$PLATFORM_LABEL" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/-+/-/g; s/^-|-$//g') ;;
+          esac
+          PRODUCT_SHORT="${{ github.event.inputs.product_name }}"
+          FAMILY=$(echo "$PRODUCT_SHORT" | awk -F'.' '{print tolower($NF)}')
+          NAME_SLUG="groupdocs-${FAMILY}-for-${PLATFORM_SLUG}-${VERSION_SLUG}"
+          ROOT_DATE=$(date +%F)
+          ROOT_DIR="${ROOT_DATE}-${FAMILY}-for-${PLATFORM_SLUG}-${VERSION_SLUG}"
+          echo "version_slug=$VERSION_SLUG" >> "$GITHUB_OUTPUT"
+          echo "platform_slug=$PLATFORM_SLUG" >> "$GITHUB_OUTPUT"
+          echo "family=$FAMILY" >> "$GITHUB_OUTPUT"
+          echo "name_slug=$NAME_SLUG" >> "$GITHUB_OUTPUT"
+          echo "root_dir=$ROOT_DIR" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python venv (cover)
+        working-directory: tools/public-release-post-cover
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Generate cover image
+        working-directory: tools/public-release-post-cover
+        run: |
+          source .venv/bin/activate
+          python generate_cover.py \
+            --product "${{ steps.build_name.outputs.full_name }}" \
+            --version "${{ github.event.inputs.version }}" \
+            --title "${{ github.event.inputs.title }}" \
+            --output ""
+
+      - name: Set up Python venv (draft)
+        working-directory: tools/public-release-post-draft
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Generate draft index.md
+        working-directory: tools/public-release-post-draft
+        env:
+          PROFESSIONALIZE_API_KEY: ${{ secrets.PROFESSIONALIZE_API_KEY }}
+          PROFESSIONALIZE_API_URL: ${{ secrets.PROFESSIONALIZE_API_URL }}
+          LOG_LEVEL: INFO
+        run: |
+          source .venv/bin/activate
+          python create_draft.py \
+            --product "${{ steps.build_name.outputs.full_name }}" \
+            --version "${{ github.event.inputs.version }}" \
+            --title "${{ github.event.inputs.title }}" \
+            --release-notes "${{ github.event.inputs.release_notes_url }}"
+
+      - name: Assemble release post folder
+        shell: bash
+        run: |
+          set -euo pipefail
+          ROOT="${{ steps.slugs.outputs.root_dir }}"
+          NAME_SLUG="${{ steps.slugs.outputs.name_slug }}"
+          mkdir -p "$ROOT/images"
+          # Copy draft index.md
+          cp tools/public-release-post-draft/output/index.md "$ROOT/index.md"
+          # Move and rename the generated cover to expected name
+          CANDIDATE=$(ls tools/public-release-post-cover/output/*.png | head -n1)
+          if [ -z "$CANDIDATE" ]; then
+            echo "No cover image found" >&2
+            exit 1
+          fi
+          cp "$CANDIDATE" "$ROOT/images/${NAME_SLUG}.png"
+          echo "Assembled: $ROOT"
+          find "$ROOT" -maxdepth 2 -type f -print
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-post-draft
+          path: ${{ steps.slugs.outputs.root_dir }}/
+          if-no-files-found: error
+
+

--- a/tools/public-release-post-draft/README.md
+++ b/tools/public-release-post-draft/README.md
@@ -1,0 +1,67 @@
+# Public Release Post Draft
+
+Generates a complete release blog post by fetching release notes, preparing front matter, creating an LLM prompt, calling the LLM for the body content, and writing the final Markdown file.
+
+## Setup
+
+```bash
+python -m venv .venv
+
+# Windows
+.venv\Scripts\activate
+
+# Linux/macOS
+source .venv/bin/activate
+
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+py ./create_draft.py \
+  --product "GroupDocs.Viewer for .NET" \
+  --version "25.9" \
+  --title "September 2025 release" \
+  --release-notes https://releases.groupdocs.com/viewer/net/release-notes/2025/groupdocs-viewer-for-net-25-9-release-notes/
+```
+
+```powershell
+python .\create_draft.py `
+  --product "GroupDocs.Viewer for .NET" `
+  --version "25.9" `
+  --title "September 2025 release" `
+  --release-notes "https://releases.groupdocs.com/viewer/net/release-notes/2025/groupdocs-viewer-for-net-25-9-release-notes/"
+```
+
+## Environment variables
+
+Set the following before running when using the LLM integration:
+
+```powershell
+$Env:PROFESSIONALIZE_API_KEY = "<your_api_key>"
+$Env:PROFESSIONALIZE_API_URL = "<your_api_url>"
+```
+
+```bash
+export PROFESSIONALIZE_API_KEY="<your_api_key>"
+export PROFESSIONALIZE_API_URL="<your_api_url>"
+
+Optional logging level (defaults to INFO):
+
+```powershell
+$Env:LOG_LEVEL = "DEBUG"
+```
+
+```bash
+export LOG_LEVEL="DEBUG"
+```
+
+## Output
+
+- Final file is written to `tools/public-release-post-draft/output/index.md`.
+- The file contains YAML front matter followed by the LLM-generated Markdown body.
+
+Notes:
+- The `--release-notes` URL should point to the public release notes page. The tool extracts the inner HTML of `<section role="main">` as the source.
+- Set both `PROFESSIONALIZE_API_KEY` and `PROFESSIONALIZE_API_URL` to enable the LLM call.

--- a/tools/public-release-post-draft/create_draft.py
+++ b/tools/public-release-post-draft/create_draft.py
@@ -1,0 +1,324 @@
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from typing import Optional, Tuple
+from datetime import datetime, timezone
+import os
+import logging
+
+import requests
+from bs4 import BeautifulSoup
+from openai import OpenAI
+
+
+@dataclass
+class DraftInputs:
+    product: str
+    version: str
+    title: str
+    release_notes_url: str
+
+
+def parse_args(argv: Optional[list[str]] = None) -> DraftInputs:
+    parser = argparse.ArgumentParser(description="Generate public release post draft inputs")
+    parser.add_argument("--product", required=True, help="Product name, e.g. 'GroupDocs.Viewer for .NET'")
+    parser.add_argument("--version", required=True, help="Product version, e.g. '25.9'")
+    parser.add_argument("--title", required=True, help="Draft title, e.g. 'September 2025 release'")
+    parser.add_argument(
+        "--release-notes",
+        required=True,
+        help=(
+            "Link to public release notes, e.g. "
+            "'https://releases.groupdocs.com/viewer/net/release-notes/2025/groupdocs-viewer-for-net-25-9-release-notes/'"
+        ),
+    )
+
+    ns = parser.parse_args(argv)
+
+    url = ns.release_notes.strip()
+    # Allow a leading '@' prefix (e.g. copied from chat)
+    url = url[1:] if url.startswith("@") else url
+
+    inputs = DraftInputs(product=ns.product, version=ns.version, title=ns.title, release_notes_url=url)
+    logging.info("Parsed inputs: product='%s', version='%s', title='%s'", inputs.product, inputs.version, inputs.title)
+    logging.info("Release notes URL: %s", inputs.release_notes_url)
+    return inputs
+
+
+def fetch_release_notes_main_section(url: str) -> str:
+    logging.info("Fetching release notes from: %s", url)
+    headers = {
+        "User-Agent": "groupdocs-blog-workflows/1.0 (+https://blog.groupdocs.com)"
+    }
+    resp = requests.get(url, headers=headers, timeout=30)
+    resp.raise_for_status()
+    logging.info("Fetched release notes: status=%s, bytes=%d", resp.status_code, len(resp.text))
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    main_section = soup.find("section", attrs={"role": "main"})
+    if not main_section:
+        # Fallback: try main tag or primary content container
+        logging.info("<section role='main'> not found, trying fallbacks <main> or div[role='main']")
+        main_section = soup.find("main") or soup.find("div", attrs={"role": "main"})
+    if not main_section:
+        raise RuntimeError("Could not locate <section role=\"main\"> in the release notes page")
+
+    # Keep inner HTML of the section to preserve structure for LLM context
+    # Trim excessive whitespace while preserving tags
+    # Note: We avoid aggressive sanitization; downstream can decide how to render.
+    html = str(main_section)
+    # Remove leading outer tag wrapper, keeping inner content
+    # e.g., <section role="main"> ... </section>
+    match = re.match(r"^<section[^>]*>([\s\S]*?)</section>\s*$", html, flags=re.IGNORECASE)
+    inner = match.group(1) if match else html
+    logging.info("Extracted main section HTML length: %d", len(inner))
+    return inner
+
+
+def _parse_month_year_from_title(title: str) -> Tuple[Optional[str], Optional[int]]:
+    logging.info("Parsing month/year from title: %s", title)
+    months = {
+        "january": 1, "february": 2, "march": 3, "april": 4, "may": 5, "june": 6,
+        "july": 7, "august": 8, "september": 9, "october": 10, "november": 11, "december": 12,
+    }
+    m = re.search(r"(january|february|march|april|may|june|july|august|september|october|november|december)\s+(\d{4})",
+                  title, flags=re.IGNORECASE)
+    if not m:
+        return None, None
+    month_name = m.group(1)
+    year = int(m.group(2))
+    # Normalize to title case month name (e.g., September)
+    norm_month = month_name[:1].upper() + month_name[1:].lower()
+    logging.info("Parsed month/year: %s %s", norm_month, year)
+    return norm_month, year
+
+
+def _slugify(text: str) -> str:
+    # Lowercase, replace non alphanum with hyphens, collapse duplicates
+    s = text.lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = re.sub(r"-+", "-", s).strip("-")
+    return s
+
+
+def _extract_family_and_platform(product: str) -> Tuple[str, str, str]:
+    # product like "GroupDocs.Viewer for .NET" -> family: viewer, product_short: GroupDocs.Viewer, platform_label: .NET
+    product_short = product.split(" for ")[0].strip()
+    family = product_short.split(".")[-1]
+    family_slug = family.lower()
+    platform_label = product.split(" for ")[-1].strip() if " for " in product else ""
+    return family_slug, product_short, platform_label
+
+
+def _platform_to_slug(platform_label: str) -> str:
+    mapping = {
+        ".NET": "net",
+        ".NET UI": "net-ui",
+        "Java": "java",
+        "Node.js": "node-js",
+        "Python": "python",
+    }
+    return mapping.get(platform_label, _slugify(platform_label))
+
+
+def _version_to_slug(version: str) -> str:
+    return version.strip().lower().replace(".", "-")
+
+
+def build_front_matter(inputs: DraftInputs) -> str:
+    # Derive components
+    month_name, year = _parse_month_year_from_title(inputs.title)
+    month_year = f"{month_name} {year}" if month_name and year else inputs.title
+    family_slug, product_short, platform_label = _extract_family_and_platform(inputs.product)
+    platform_slug = _platform_to_slug(platform_label)
+    version_slug = _version_to_slug(inputs.version)
+    name_slug = f"groupdocs-{family_slug}-for-{platform_slug}-{version_slug}"
+    url = f"/{family_slug}/{name_slug}/"
+    logging.info("Front matter slugs: family=%s, platform=%s, version=%s", family_slug, platform_slug, version_slug)
+    logging.info("Post URL: %s", url)
+
+    # Title and SEO
+    title = f"{inputs.product} {inputs.version} – {month_year} Release Highlights"
+    seo_title = f"{inputs.product} {inputs.version} – Latest Updates and Fixes ({month_year})"
+    description = f"Explore what’s new in {inputs.product} {inputs.version}. Available now on NuGet and GroupDocs website."
+    summary = f"{inputs.product} {inputs.version} is here."
+
+    # Date in RFC 1123 format at midnight UTC
+    now = datetime.now(timezone.utc)
+    rfc1123 = now.strftime("%a, %d %b %Y 00:00:00 +0000")
+
+    # Tags and categories
+    tags = [product_short, platform_label, "Releases"] if platform_label else [product_short, "Releases"]
+    categories = [f"{product_short} Releases"]
+
+    # Cover
+    cover_image = f"{url}images/{name_slug}.png"
+    cover_alt = title
+    cover_caption = title
+
+    # Render YAML front matter
+    # Note: Using explicit newlines and spaces to control formatting precisely.
+    fm_lines = [
+        "---",
+        f"title: \"{title}\"",
+        f"seoTitle: \"{seo_title}\"",
+        f"description: \"{description}\"",
+        f"date: {rfc1123}",
+        "draft: false",
+        f"url: {url}",
+        "author: \"GroupDocs Team\"",
+        f"summary: \"{summary}\"",
+        f"tags: ['{tags[0]}', '{tags[1]}'{'' if len(tags) == 2 else ", '" + "', '".join(tags[2:]) + "'"}]",
+        f"categories: ['{categories[0]}']",
+        "showToc: true",
+        "tocOpen: true",
+        "cover:",
+        f"    image: {cover_image}",
+        f"    alt: \"{cover_alt}\"",
+        f"    caption: \"{cover_caption}\"",
+        "    hidden: false",
+        "---",
+    ]
+    fm = "\n".join(fm_lines)
+    logging.info("Built front matter length: %d", len(fm))
+    return fm
+
+
+def build_llm_prompt(inputs: DraftInputs, release_notes_html: str) -> str:
+    # Provide the model with clear structure and a concrete example to emulate.
+    example_template = (
+        "We’re happy to announce the major release of **{product} {version}**, available as of **{month_year}**. "
+        "This major release delivers two new features with public API changes, one enhancement and 4 fixed bug.\n\n"
+        "## New features\n\n"
+        "* **[New feature]** Introduce distinct font type for each formats family (VIEWERNET-5486)\n"
+        "* **[New feature]** List substituted fonts when getting all fonts for the WordProcessing family formats (VIEWERNET-5484)\n\n"
+        "Both these features continue to improve the mechanism of extracting and listing used fonts of the loaded document. "
+        "In short, with VIEWERNET-5484 the GroupDocs.Viewer is now possible to list and return the _substitutuion fonts_, which are not present in original document, "
+        "but are used to replace those original fonts, which are missing and thus unavailable on a target machine (where the GroupDocs.Viewer is running). "
+        "The VIEWERNET-5486 feature improves the public API — instead of a single `UsedFontInfo` type now there is a `IFontInfo` interfave and a plenty of its inheritors — one per each formats family. "
+        "Visit the article \"[Getting all used fonts in the loaded document ](https://docs.groupdocs.com/viewer/net/getting-used-fonts/)\" in public documentation for the further details.\n\n"
+        "## Fixes and enhancements\n\n"
+        "* **[Enhancement]** Embed fonts when converting Spreadsheet documents to embedded HTML. (VIEWERNET-5490)\n"
+        "* **[Fix]** PDF attachment in base PDF in rendered to HTML format with issues. (VIEWERNET-5374)  \n"
+        "* **[Fix]** Gradient on background is not correct when rendering PDF to HTML. (VIEWERNET-5345)  \n"
+        "* **[Fix]** Failed to load specific PSD. (VIEWERNET-3780)  \n"
+        "* **[Fix]** [UI] Groupdocs Viewer 8.0.7 - Wrong page no displayed initially during server delays to return pages. (VIEWERNET-5485)  \n\n"
+        "## How to get the update\n\n"
+        "- **NuGet** – Upgrade to the latest `{product}` package via NuGet. Choose the package for your target platform: "
+        "[Cross-platform .NET 6 Package](https://www.nuget.org/packages/GroupDocs.Viewer.CrossPlatform/{version}) or "
+        "[Windows-only .NET Framework 4.6.2 and .NET 6 Package](https://www.nuget.org/packages/GroupDocs.Viewer/{version})  \n"
+        "- **Direct Download** – Download assemblies for both .NET and .NET Framework from the "
+        "[GroupDocs.Viewer for .NET {version}](https://releases.groupdocs.com/viewer/net/new-releases/groupdocs.viewer-for-.net-{version}-dlls-only/) page\n\n"
+        "## Learn more\n\n"
+        "* [Full Release Notes]({release_notes_url})  \n"
+        "* [Documentation](https://docs.groupdocs.com/viewer/net/)  \n"
+        "* [GroupDocs.Viewer Free Support Forum](https://forum.groupdocs.com/c/viewer/9)  \n\n"
+        "---\n"
+    )
+
+    prompt = (
+        f"You are drafting a public release blog post for {inputs.product} v{inputs.version}.\n"
+        f"Title: {inputs.title}\n\n"
+        "Use the following release notes HTML (from the main content of the page) as the source of truth. "
+        "Extract the key changes, list new features, improvements, and fixed issues, and produce a clear, reader-friendly "
+        "blog draft in Markdown. Follow the tone and structure of the example template below, "
+        "adapting names, links, and counts to match this release. Keep wording precise and technical, not marketing-heavy.\n\n"
+        "<example_template>\n"
+        f"{example_template}\n"
+        "</example_template>\n\n"
+        "Use the provided front matter below as the exact header (YAML) for the post. Generate ONLY the body content after it.\n\n"
+        "<front_matter>\n"
+        f"{build_front_matter(inputs)}\n"
+        "</front_matter>\n\n"
+        "When generating links, prefer those found in the release notes. If unavailable, omit.\n\n"
+        "<release_notes>\n"
+        f"{release_notes_html}\n"
+        "</release_notes>\n"
+    )
+    logging.info("Built LLM prompt length: %d", len(prompt))
+    return prompt
+
+
+def call_llm_generate_draft(prompt: str) -> str:
+    logging.info("Calling LLM to generate draft body")
+    api_key = os.getenv("PROFESSIONALIZE_API_KEY")
+    if not api_key:
+        raise RuntimeError("Missing PROFESSIONALIZE_API_KEY environment variable")
+
+    api_url = os.getenv("PROFESSIONALIZE_API_URL")
+    if not api_url:
+        raise RuntimeError("Missing PROFESSIONALIZE_API_URL environment variable")
+
+    client = OpenAI(api_key=api_key, base_url=api_url)
+
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are a professional tech blog writer. "
+                "Write articles for Hugo in Markdown"
+                "Keep the content accurate and concise."
+            ),
+        },
+        {
+            "role": "user",
+            "content": prompt,
+        },
+    ]
+
+    # For Professionalize
+    response = client.chat.completions.create(model="recommended", messages=messages)
+    content = response.choices[0].message.content.strip()
+    logging.info("LLM response length: %d", len(content))
+    return content
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    try:
+        # Basic logging setup; respect LOG_LEVEL if set, default to INFO
+        log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+        logging.basicConfig(level=getattr(logging, log_level, logging.INFO), format="%(levelname)s %(message)s")
+        logging.info("Starting draft generation pipeline")
+        inputs = parse_args(argv)
+        notes_html = fetch_release_notes_main_section(inputs.release_notes_url)
+        front_matter = build_front_matter(inputs)
+        prompt = build_llm_prompt(inputs, notes_html)
+
+        # Generate blog body via LLM
+        body_md = call_llm_generate_draft(prompt)
+
+        # If the model returned front matter (despite instructions), strip it
+        def _strip_front_matter(text: str) -> str:
+            t = text.lstrip("\ufeff\n\r ")
+            if t.startswith("---"):
+                # remove first front matter block
+                m = re.search(r"^---[\s\S]*?\n---\s*\n?", t)
+                if m:
+                    return t[m.end():]
+            return t
+
+        before_len = len(body_md)
+        body_md = _strip_front_matter(body_md).lstrip()
+        logging.info("Post-processed body: before=%d, after=%d", before_len, len(body_md))
+
+        final_md = f"{front_matter}\n\n{body_md}\n"
+
+        # Save to output/index.md within tool directory
+        out_dir = os.path.join(os.path.dirname(__file__), "output")
+        os.makedirs(out_dir, exist_ok=True)
+        out_path = os.path.join(out_dir, "index.md")
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(final_md)
+        logging.info("Saved final markdown: %s (chars=%d)", out_path, len(final_md))
+        return 0
+    except Exception as exc:
+        logging.error("Error: %s", exc)
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/tools/public-release-post-draft/output/index.md
+++ b/tools/public-release-post-draft/output/index.md
@@ -1,0 +1,61 @@
+---
+title: "GroupDocs.Total for .NET 25.8 – September 2025 Release Highlights"
+seoTitle: "GroupDocs.Total for .NET 25.8 – Latest Updates and Fixes (September 2025)"
+description: "Explore what’s new in GroupDocs.Total for .NET 25.8. Available now on NuGet and GroupDocs website."
+date: Wed, 01 Oct 2025 00:00:00 +0000
+draft: false
+url: /total/groupdocs-total-for-net-25-8/
+author: "GroupDocs Team"
+summary: "GroupDocs.Total for .NET 25.8 is here."
+tags: ['GroupDocs.Total', '.NET', 'Releases']
+categories: ['GroupDocs.Total Releases']
+showToc: true
+tocOpen: true
+cover:
+    image: /total/groupdocs-total-for-net-25-8/images/groupdocs-total-for-net-25-8.png
+    alt: "GroupDocs.Total for .NET 25.8 – September 2025 Release Highlights"
+    caption: "GroupDocs.Total for .NET 25.8 – September 2025 Release Highlights"
+    hidden: false
+---
+
+We’re happy to announce the **GroupDocs.Total for .NET 25.8** release, available as of **September 2025**. This update brings a few critical bug fixes, an important packaging change, and the usual version upgrades of the individual libraries that compose the Total suite.
+
+## Important notice
+
+> Starting with this version **GroupDocs.Classification** is no longer shipped inside the **GroupDocs.Total** package.  
+> The classification library adds large machine‑learning model files, which increased the overall package size and affected performance for users who do not need classification capabilities.  
+> If you rely on classification, add the library separately (see the **GroupDocs.Classification** NuGet package or its own release notes).
+
+## Fixes
+
+| Issue | Product | Description |
+|-------|-----------|-------------|
+| **TOTALNET‑204** | Conversion | Fixed incorrect table formatting when converting HTML → PDF. |
+| **TOTALNET‑287** | Annotation | Resolved missing localized string error: “CONSTRUCTOR.WITH.PARAMETERS.STARTED” key does not exist. |
+| **TOTALNET‑298** | Viewer | Fixed a null‑reference exception that occurred on diagram rendering. |
+
+No new public‑API features or enhancements were introduced in this release.
+
+## How to get the update
+
+- **NuGet** – Upgrade the **GroupDocs.Total** package (or the .NET Framework‑specific package) to the latest version:  
+
+  * [.NET 6 / .NET Standard 2.0]([https://www.nuget.org/packages/GroupDocs.Total](https://www.nuget.org/packages/GroupDocs.Total))  
+  * [.NET Framework 4.6.2 +]([https://www.nuget.org/packages/GroupDocs.Total.NETFramework](https://www.nuget.org/packages/GroupDocs.Total.NETFramework))
+
+- **Direct download** – Grab the compiled assemblies for both .NET 6 and .NET Framework from the **[GroupDocs.Total for .NET 25.8 download page]**(https://releases.groupdocs.com/total/net/#direct-download).
+
+## Learn more
+
+- **Full release notes** – Detailed change log for each library in the suite:  
+
+  * [GroupDocs.Conversion 25.8]([https://releases.groupdocs.com/conversion/net/release-notes/2025/groupdocs-conversion-for-net-25-8-release-notes/])  
+  * [GroupDocs.Viewer 25.8]([https://releases.groupdocs.com/viewer/net/release-notes/2025/groupdocs-viewer-for-net-25-8-release-notes/])  
+  * [GroupDocs.Comparison 25.8]([https://releases.groupdocs.com/comparison/net/release-notes/2025/groupdocs-comparison-for-net-25-8-release-notes/])  
+  * …and the other components listed in the release notes table.
+
+- **Documentation** – Comprehensive API reference and usage guides: <https://docs.groupdocs.com/total/net/>
+
+- **Support** – Post questions, report issues, or share feedback on the **[GroupDocs.Total Free Support Forum]**(https://forum.groupdocs.com/c/total/8).
+
+---

--- a/tools/public-release-post-draft/requirements.txt
+++ b/tools/public-release-post-draft/requirements.txt
@@ -1,0 +1,6 @@
+requests>=2.31.0
+beautifulsoup4>=4.12.2
+openai>=1.51.0
+
+
+


### PR DESCRIPTION
The agent downloads release notes and creates draft for the blog post about the product release e.g. https://blog.groupdocs.com/conversion/groupdocs-conversion-for-net-25-9/

## Usage

```bash
py ./create_draft.py \
  --product "GroupDocs.Viewer for .NET" \
  --version "25.9" \
  --title "September 2025 release" \
  --release-notes https://releases.groupdocs.com/viewer/net/release-notes/2025/groupdocs-viewer-for-net-25-9-release-notes/
```

```powershell
python .\create_draft.py `
  --product "GroupDocs.Viewer for .NET" `
  --version "25.9" `
  --title "September 2025 release" `
  --release-notes "https://releases.groupdocs.com/viewer/net/release-notes/2025/groupdocs-viewer-for-net-25-9-release-notes/"
```